### PR TITLE
Remove --start flag from call to hoogle

### DIFF
--- a/plugin/hoogle.vim
+++ b/plugin/hoogle.vim
@@ -162,7 +162,7 @@ fun! HoogleLineJump() "{{{
   if exists('b:hoogle_search') == 0
     return
   endif
-  call HoogleLookup( b:hoogle_search, ' --info --start=' . line('.') )
+  call HoogleLookup( b:hoogle_search, ' --info' )
   unlet b:hoogle_search
 endfunction "}}}
 


### PR DESCRIPTION
From #2, you should be able to look up the word under the cursor using the enter key. However, instead of doing that, the error message 'Unknown flag: --start' was shown. It seems that for some reason a flag --start was being passed to hoogle. This change removes the unnecessary flag. It all still seems to work.