### PR TITLE
Added norelativenumber to the scratchbuffer

### DIFF
--- a/plugin/hoogle.vim
+++ b/plugin/hoogle.vim
@@ -49,6 +49,7 @@ function! s:ScratchMarkBuffer()
     setlocal noswapfile
     setlocal buflisted
     setlocal nonumber
+    setlocal norelativenumber
     setlocal statusline=%F
     setlocal nofoldenable
     setlocal foldcolumn=0


### PR DESCRIPTION
The scratch window didn't set rnu and was showing line numbers for me 