### PR TITLE
Use searchpos to get the full enclosed word instead of expanding <cword>

### DIFF
--- a/plugin/hoogle.vim
+++ b/plugin/hoogle.vim
@@ -105,15 +105,18 @@ fun! HoogleCloseSearch() "{{{
 endfunction "}}}
 
 fun! s:GetFullWord()
-  let l:line = getline('.')
-  let l:start = max([0, searchpos('\s', 'bn', line('.'))[1]])
-  let l:end = searchpos('\s', 'n', line('.'))[1]
+  let line = getline('.')
+  let line_n = line('.')
+  let col_n = col('.')
 
-  if !l:end
-    let l:end = searchpos('[\n|\r]', 'n', line('.'))[1]
+  let start = max([0, searchpos('\s', 'bcn', line_n)[1]])
+  let end = searchpos('\s', 'cn', line_n)[1]
+
+  if end == 0
+    let end = searchpos('[\n|\r]', 'cn', line('.'))[1]
   endif
 
-  return strpart(l:line, l:start, l:end - l:start)
+  return strpart(line, start, end - start)
 endfunction
 
 " Open a scratch buffer or reuse the previous one

--- a/plugin/hoogle.vim
+++ b/plugin/hoogle.vim
@@ -107,12 +107,11 @@ endfunction "}}}
 fun! s:GetFullWord()
   let line = getline('.')
   let line_n = line('.')
-  let col_n = col('.')
 
   let start = max([0, searchpos('\s', 'bcn', line_n)[1]])
   let end = searchpos('\s', 'cn', line_n)[1]
 
-  if end == 0
+  if !end
     let end = searchpos('[\n|\r]', 'cn', line('.'))[1]
   endif
 

--- a/plugin/hoogle.vim
+++ b/plugin/hoogle.vim
@@ -104,13 +104,30 @@ fun! HoogleCloseSearch() "{{{
     exe win_num . "wincmd w"
 endfunction "}}}
 
+fun! s:GetFullWord()
+  let l:line = getline('.')
+  let l:start = max([0, searchpos('\s', 'bn', line('.'))[1]])
+  let l:end = searchpos('\s', 'n', line('.'))[1]
+
+  if !l:end
+    let l:end = searchpos('[\n|\r]', 'n', line('.'))[1]
+  endif
+
+  return strpart(l:line, l:start, l:end - l:start)
+endfunction
+
 " Open a scratch buffer or reuse the previous one
 fun! HoogleLookup( search, args ) "{{{
     " Ok, previous buffer to jump to it at final
     let last_buffer = bufnr("%")
 
     if strlen(a:search) == 0
+      try
+        let s:search = s:GetFullWord()
+      catch
+        " Fallback to <cword> expansion if the word can't be get otherwise.
         let s:search = expand("<cword>")
+      endtry
     else
         let s:search = a:search
     endif


### PR DESCRIPTION
When you use :Hoogle without passing any parameters, it uses `expand("<cword>")` to get the underlying word under the cursor.

For fully qualified module names, like `Graphics.Gloss.Data.ViewPort`, it would only get the word between the dots around your cursor position.

By using **searchpos** instead, it matches with the surrounding spaces either side and/or the newline characters, resulting in capturing the full text object (even operators like '<$>').